### PR TITLE
Update upstream

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "docs/themes/meteor"]
-	path = docs/themes/meteor
-	url = https://github.com/meteor/hexo-theme-meteor.git

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,1 @@
+_multiconfig.yml

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,17 +1,19 @@
-# Hexo Configuration
-## Docs: http://hexo.io/docs/configuration.html
-## Source: https://github.com/hexojs/hexo/
-
-# Site
+github_repo: apollographql/apollo-client
 title: Apollo Client
 propertytitle: Using GraphQL with Apollo Client
 subtitle: React Guide
 description: A guide to using the Apollo GraphQL Client with React.
-author:
-language:
-timezone:
 versions:
   - '1'
+
+content_root: docs/source
+public_dir: public/docs/react
+
+url: https://www.apollographql.com/docs/react
+root: /docs/react/
+
+typescript_api_box:
+  data_file: docs.json
 
 # This setting also defines the page order used to generate the Previous/Next links at the bottom of each page
 sidebar_categories:
@@ -52,80 +54,3 @@ sidebar_categories:
     - recipes/recompose
   Reference:
     - reference/index
-
-
-github_repo: apollographql/apollo-client
-content_root: docs/source
-
-social_links:
-  github: 'https://github.com/apollographql'
-  twitter: '@apollographql'
-  slackInvitePage: 'https://www.apollodata.com/#slack'
-
-typescript_api_box:
-  data_file: docs.json
-
-# API keys
-apis:
-  segment: wgrIo8Bul0Ujl8USETG3DB6hONdy4kTg
-  gtm: GTM-PNFDVBB
-
-# URL
-## If your site is put in a subdirectory, set url as 'http://yoursite.com/child' and root as '/child/'
-url: https://www.apollographql.com/docs/react
-root: /docs/react/
-permalink: :year/:month/:day/:title/
-permalink_defaults:
-
-# Directory
-source_dir: source
-public_dir: public/docs/react
-tag_dir: tags
-archive_dir: archives
-category_dir: categories
-code_dir: downloads/code
-i18n_dir: :lang
-skip_render:
-
-# Writing
-new_post_name: :title.md # File name of new posts
-default_layout: post
-titlecase: false # Transform title into titlecase
-external_link: true # Open external links in new tab
-filename_case: 0
-render_drafts: false
-post_asset_folder: false
-relative_link: false
-future: true
-highlight:
-  enable: true
-  line_number: true
-  auto_detect: true
-  tab_replace:
-
-# Category & Tag
-default_category: uncategorized
-category_map:
-tag_map:
-
-# Date / Time format
-## Hexo uses Moment.js to parse and display date
-## You can customize the date format as defined in
-## http://momentjs.com/docs/#/displaying/format/
-date_format: YYYY-MM-DD
-time_format: HH:mm:ss
-
-# Pagination
-## Set per_page to 0 to disable pagination
-per_page: 10
-pagination_dir: page
-
-# Extensions
-## Plugins: http://hexo.io/plugins/
-## Themes: http://hexo.io/themes/
-theme: meteor
-
-# Deployment
-## Docs: http://hexo.io/docs/deployment.html
-deploy:
-  type:

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,26 +3,35 @@
   "version": "0.0.0",
   "private": true,
   "hexo": {
-    "version": "3.4.3"
+    "version": "3.6.0"
   },
-  "dependencies": {
-    "hexo": "3.4.4",
-    "hexo-generator-archive": "^0.1.2",
-    "hexo-generator-category": "^0.1.2",
-    "hexo-generator-index": "^0.2.0",
-    "hexo-generator-tag": "^0.2.0",
-    "hexo-renderer-ejs": "^0.3.0",
-    "hexo-renderer-less": "^0.2.0",
-    "hexo-renderer-marked": "^0.3.0",
-    "hexo-server": "^0.3.0",
+  "devDependencies": {
+    "apollo-hexo-config": "^1.0.2",
+    "chexo": "^1.0.4",
+    "hexo": "3.6.0",
+    "hexo-generator-archive": "0.1.5",
+    "hexo-generator-category": "0.1.3",
+    "hexo-generator-index": "0.2.1",
+    "hexo-generator-tag": "0.2.0",
+    "hexo-renderer-ejs": "0.3.1",
+    "hexo-renderer-less": "0.2.0",
+    "hexo-renderer-marked": "0.3.2",
+    "hexo-server": "0.3.1",
     "hexo-typescript-api-box": "^0.9.1",
+    "meteor-theme-hexo": "^1.0.1",
     "typedoc": "^0.9.0",
     "typescript": "^2.5.3"
   },
   "scripts": {
-    "types":
-      "cd ../packages/apollo-client && typedoc --json ../../docs/docs.json --ignoreCompilerErrors ./src/index.ts",
-    "build": "npm run types && hexo generate",
-    "start": "hexo serve"
+    "start": "npm run build && chexo apollo-hexo-config -- server",
+    "types": "cd ../packages/apollo-client && typedoc --json ../../docs/docs.json --ignoreCompilerErrors ./src/index.ts",
+    "build": "npm run types && chexo apollo-hexo-config -- generate",
+    "clean": "hexo clean",
+    "test": "npm run clean; npm run build"
+  },
+  "renovate": {
+    "extends": [
+      "apollo-docs"
+    ]
   }
 }


### PR DESCRIPTION
…148)

* docs: Make `scripts` consistent across "docs" repos.

For example, the `test` and `start` commands.

* docs: Use `devDependencies` instead of `dependencies`.

It's safe to mark all dependencies of this theme as 'dev' dependencies, as
none of them are needed to be installed in a production setting.

This was done automatically, so in some cases, this merges existing
`devDependencies`, and may also have added a missing `nodemon` `devDependency`
in cases where it was missing.  In other cases, this commit may not have
made such a change.

* docs: Fix top-level `hexo` versions in docs `package.json`s.

This is just metadata used by Hexo, but it's meant to be updated and committed.

* docs: Remove _config.yml options now covered by global theme config.

* docs: Add `_multiconfig.yml`, a build artifact, to docs `.gitignore`.

* docs: Use theme from npm, rather than submodule, using `chexo`.

The theme which the docs in this repository are based on
([`hexo-theme-meteor`](https://github.com/meteor/hexo-theme-meteor)) has been
published to npm.

Additionally, most of the configuration which was once present in this
repository's `_config.yml` file, has been moved into an Apollo-centric theme
configuration npm,
[`apollo-hexo-config`](https://www.npmjs.com/package/apollo-hexo-config) (and
similarly, [GitHub](https://github.com/apollographql/apollo-hexo-config)).

The theme bundled in this npm is a converged version of the two `apollo`
and `master` branches on the `hexo-theme-meteor` repository, which is a result
of the work undertaken in https://github.com/meteor/hexo-theme-meteor/pull/51.

Lastly, this makes use of a new `chexo` npm which acts as a wrapper for `hexo`
but permits the use of an inherited configuration from npm, rather than a
statically defined CLI file parameter (previously with `--config a,b`).

* docs: Upgrade Hexo to 3.6.0.

* docs: Upgrade Hexo generator/tag/server dependencies.

* docs: Add Renovate configuration.

While some repositories which host Hexo docs alongside other code may not have
Renovate setup, it's anticipated that they will in the future, at the very
least for the docs portions of the respective repositories.

By having this `renovate` section in the `package.json` for the Hexo docs, we
can ensure that they will receive the proper treatment and minimize the amount
of manual work necessary on those repositories.

Additionally, this ensures that there is a single point of upstream Apollo-docs
Renovate configuration through the use of the
[`renovate-config-apollo-docs`](https://npm.im/renovate-config-apollo-docs)
package, which inherits further from
[`renovate-config-mdg-docs`](https://npm.im/renovate-config-mdg-docs).

Repositories which already have Renovate setup should benefit automatically
from this new docs-specific configuration.

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->