### PR TITLE
Update upstream

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -1,6 +1,5 @@
-// Removed import
-import { includes } from 'lodash';
-import * as fs from 'fs';
+const { includes } = require('lodash');
+const fs = require('fs');
 
 // Setup
 const github = danger.github;

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   ],
   "jest": {
     "transform": {
-      ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+      ".(ts|tsx)": "ts-jest"
     },
     "testURL": "http://localhost"
   },
@@ -73,7 +73,8 @@
     "bundlesize": "0.17.0",
     "check-if-folder-contents-changed-in-git-commit-range": "1.0.0",
     "codecov": "3.0.4",
-    "danger": "1.2.0",
+    "danger": "3.8.6",
+    "jest": "^23.5.0",
     "jest-junit": "5.1.0",
     "lerna": "2.11.0",
     "lint-staged": "6.1.0",
@@ -82,7 +83,7 @@
     "rollup-plugin-local-resolve": "1.0.7",
     "rollup-plugin-node-resolve": "3.3.0",
     "rollup-plugin-sourcemaps": "0.4.2",
-    "ts-jest": "20.0.14",
+    "ts-jest": "23.1.3",
     "typescript": "3.0.1"
   }
 }

--- a/packages/apollo-boost/package.json
+++ b/packages/apollo-boost/package.json
@@ -53,14 +53,14 @@
     "jest": "23.5.0",
     "lodash": "4.17.10",
     "rimraf": "2.6.2",
-    "ts-jest": "20.0.14",
+    "ts-jest": "23.1.3",
     "tslint": "5.11.0",
     "typescript": "3.0.1",
     "uglify-js": "3.4.7"
   },
   "jest": {
     "transform": {
-      ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+      ".(ts|tsx)": "ts-jest"
     },
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
     "moduleFileExtensions": [

--- a/packages/apollo-cache-inmemory/package.json
+++ b/packages/apollo-cache-inmemory/package.json
@@ -58,14 +58,14 @@
     "lodash": "4.17.10",
     "rimraf": "2.6.2",
     "rollup": "0.64.1",
-    "ts-jest": "20.0.14",
+    "ts-jest": "23.1.3",
     "tslint": "5.11.0",
     "typescript": "3.0.1",
     "uglify-js": "3.4.7"
   },
   "jest": {
     "transform": {
-      ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+      ".(ts|tsx)": "ts-jest"
     },
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
     "moduleFileExtensions": [

--- a/packages/apollo-cache/package.json
+++ b/packages/apollo-cache/package.json
@@ -51,14 +51,14 @@
     "rimraf": "2.6.2",
     "rollup": "0.64.1",
     "rollup-plugin-node-resolve": "3.3.0",
-    "ts-jest": "20.0.14",
+    "ts-jest": "23.1.3",
     "tslint": "5.11.0",
     "typescript": "3.0.1",
     "uglify-js": "3.4.7"
   },
   "jest": {
     "transform": {
-      ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+      ".(ts|tsx)": "ts-jest"
     },
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
     "moduleFileExtensions": [

--- a/packages/apollo-client/package.json
+++ b/packages/apollo-client/package.json
@@ -79,7 +79,7 @@
     "lodash": "4.17.10",
     "rollup": "0.64.1",
     "rxjs": "6.2.2",
-    "ts-jest": "20.0.14",
+    "ts-jest": "23.1.3",
     "tslint": "5.11.0",
     "typescript": "3.0.1",
     "uglify-js": "3.4.7",
@@ -91,7 +91,7 @@
   },
   "jest": {
     "transform": {
-      ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+      ".(ts|tsx)": "ts-jest"
     },
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
     "moduleFileExtensions": [

--- a/packages/apollo-client/tsconfig.json
+++ b/packages/apollo-client/tsconfig.json
@@ -4,7 +4,7 @@
     "rootDir": "src",
     "outDir": "lib",
     "noLib": true,
-    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "strictNullChecks": true,

--- a/packages/apollo-utilities/package.json
+++ b/packages/apollo-utilities/package.json
@@ -54,14 +54,14 @@
     "lodash": "4.17.10",
     "rimraf": "2.6.2",
     "rollup": "0.64.1",
-    "ts-jest": "20.0.14",
+    "ts-jest": "23.1.3",
     "tslint": "5.11.0",
     "typescript": "3.0.1",
     "uglify-js": "3.4.7"
   },
   "jest": {
     "transform": {
-      ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+      ".(ts|tsx)": "ts-jest"
     },
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
     "moduleFileExtensions": [

--- a/packages/apollo-utilities/src/storeUtils.ts
+++ b/packages/apollo-utilities/src/storeUtils.ts
@@ -199,7 +199,7 @@ export function getStoreKeyName(
       (directives['connection']['filter'] as string[]).length > 0
     ) {
       const filterKeys = directives['connection']['filter']
-        ? directives['connection']['filter'] as string[]
+        ? (directives['connection']['filter'] as string[])
         : [];
       filterKeys.sort();
 
@@ -286,9 +286,9 @@ export function toIdValue(
   return {
     type: 'id',
     generated,
-    ...typeof idConfig === 'string'
+    ...(typeof idConfig === 'string'
       ? { id: idConfig, typename: undefined }
-      : idConfig,
+      : idConfig),
   };
 }
 

--- a/packages/apollo-utilities/tsconfig.json
+++ b/packages/apollo-utilities/tsconfig.json
@@ -4,7 +4,7 @@
     "rootDir": "./src",
     "outDir": "lib",
     "lib": ["es6", "dom", "es2017.object"],
-    "allowSyntheticDefaultImports": true
+    "esModuleInterop": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["src/**/__tests__/*.ts"]

--- a/packages/graphql-anywhere/package.json
+++ b/packages/graphql-anywhere/package.json
@@ -56,14 +56,14 @@
     "react": "15.6.2",
     "react-dom": "15.6.2",
     "rollup": "0.64.1",
-    "ts-jest": "20.0.14",
+    "ts-jest": "23.1.3",
     "tslint": "5.11.0",
     "typescript": "3.0.1",
     "uglify": "0.1.5"
   },
   "jest": {
     "transform": {
-      ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+      ".(ts|tsx)": "ts-jest"
     },
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
     "moduleFileExtensions": [

--- a/packages/graphql-anywhere/tsconfig.json
+++ b/packages/graphql-anywhere/tsconfig.json
@@ -4,7 +4,7 @@
     "noImplicitAny": false,
     "rootDir": "src",
     "outDir": "lib",
-    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "lib": ["es6", "dom", "es2017.object"]
   },
   "include": ["src/**/*.ts"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "moduleResolution": "node",
     "declaration": true,
     "noLib": true,
-    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "removeComments": false
   }
 }


### PR DESCRIPTION
* chore(deps): update dependency ts-jest to v23
* Address deprecation notices; Fix `stringify` default import
* Adjust to use `esModuleInterop` instead of TS default approach
* Troubleshooting danger
* Replace `allowSyntheticDefaultImports` with `esModuleInterop`
* Switch import style
* Adjust root dir to appease ts-jest
* Update danger versions
* Revert danger to older version
* Update danger version; Revert to require's for danger

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
