### PR TITLE
keyof for arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Apollo Client (vNext)
 
+- A new `ObservableQuery.resetQueryStoreErrors()` method is now available that
+  can be used to clear out `ObservableQuery` query store errors.  <br/>
+  [@hwillson](https://github.com/hwillson) in [#4941](https://github.com/apollographql/apollo-client/pull/4941)
 - Documentation updates.  <br/>
   [@michael-watson](https://github.com/michael-watson) in [#4940](https://github.com/apollographql/apollo-client/pull/4940)  <br/>
   [@hwillson](https://github.com/hwillson) in [#4969](https://github.com/apollographql/apollo-client/pull/4969)

--- a/packages/apollo-client/src/core/ObservableQuery.ts
+++ b/packages/apollo-client/src/core/ObservableQuery.ts
@@ -280,6 +280,14 @@ export class ObservableQuery<
     this.isTornDown = false;
   }
 
+  public resetQueryStoreErrors() {
+    const queryStore = this.queryManager.queryStore.get(this.queryId);
+    if (queryStore) {
+      queryStore.networkError = null;
+      queryStore.graphQLErrors = [];
+    }
+  }
+
   /**
    * Update the variables of this observable query, and fetch the new results.
    * This method should be preferred over `setVariables` in most use cases.


### PR DESCRIPTION
…(#4941)

* Reset query store errors via `ObservableQuery.resetQueryStoreErrors`

React Apollo relies on the `ObervableQuery->getCurrentResult`
method to retrieve query results to show within its components.
When an error occurs while fetching results, that error is stored
in the query store that each `ObservableQuery` instance is
configured to use. Unfortunately, `getCurrentResult` will only
retrieve subsequent results if no error exists in the query store.
`ObservableQuery` doesn't currently provide a way to clear out
query store errors, which means when React Apollo originating
requests that cause an error occur, the error is stored, and
future valid requests can no longer be processed.

This commit adds a `resetQueryStoreErrors` method to the
`ObservableQuery` public API, that will allow React Apollo (and
other consumers) to be able to clear out query store errors.

Related to: https://github.com/apollographql/react-apollo/issues/3090

* Changelog update

* Remove unnecessary expect

<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
